### PR TITLE
Update Qwoyn Validator to Arcane Forge

### DIFF
--- a/add_qwoyn
+++ b/add_qwoyn
@@ -1,11 +1,13 @@
-Add Qwoyn validator to the list of test-net validators
+Add Arcane Forge validator to the list of test-net validators
 
 # List of Cosmos Ecosystem main-nets:
 
 - [Regen Network](https://www.mintscan.io/regen/validators/regenvaloper1wm7d4285myyd276zcnhex73eyhqh0h7jh0kst0)
 - [Gravity Bridge](https://www.mintscan.io/gravity-bridge/validators/gravityvaloper17399gtlvfyavwx7afu7w5rjw5f2kwe7wmtthv3)
 - [Andromeda](https://explorer.stavr.tech/Andromeda-Mainnet/staking/andrvaloper1lyj0adepn0eaeur7da6lkg3q2zdsxz9p370kmh)
+- [C4E](https://explorer.c4e.io/validators/c4evaloper1s2dzw5nngw6v3y5c7v38hct672vldmy8p58y5a)
 
 # Contacts
 
 https://t.me/qwoyn
+devops@arcaneforge.io


### PR DESCRIPTION
The Qwoyn validator service is now called Arcane Forge